### PR TITLE
Use ReactNative WebView instead of Bridge.

### DIFF
--- a/components/EpubView.js
+++ b/components/EpubView.js
@@ -9,7 +9,6 @@ import {
   TouchableWithoutFeedback,
 } from 'react-native';
 
-import WebViewBridge from 'react-native-webview-bridge';
 const core = require('epubjs/src/core');
 
 class EpubView extends Component {
@@ -77,10 +76,6 @@ class EpubView extends Component {
       });
   }
 
-  componentDidMount() {
-    this.bridge = this.refs.webviewbridge;
-  }
-
   reset() {
     // this.rendering = new RSVP.defer();
     // this.rendered = this.rendering.promise;
@@ -96,11 +91,10 @@ class EpubView extends Component {
       (function () {
 
         function _ready() {
-          var bridge = WebViewBridge;
           var contents;
 
           if (typeof ePub === "undefined") {
-            return bridge.send(JSON.stringify({
+            return window.postMessage(JSON.stringify({
               method: "error",
               value: "EPUB.js is not loaded"
             }));
@@ -108,8 +102,8 @@ class EpubView extends Component {
 
           contents = new ePub.Contents(document);
           window.contents = contents;
-          bridge.onMessage = function (message) {
-            var decoded = JSON.parse(message);
+          document.addEventListener('message', function (message) {
+            var decoded = JSON.parse(message.data);
             var response;
             var result;
 
@@ -122,29 +116,27 @@ class EpubView extends Component {
                 value: result
               });
 
-              bridge.send(response);
+              window.postMessage(response);
 
             }
-          };
+        });
 
           contents.on("resize", function (size) {
-            bridge.send(JSON.stringify({method:"resize", value: size }));
+            window.postMessage(JSON.stringify({method:"resize", value: size }));
           });
 
           contents.on("expand", function () {
-            bridge.send(JSON.stringify({method:"expand", value: true}));
+            window.postMessage(JSON.stringify({method:"expand", value: true}));
           });
 
-          bridge.send(JSON.stringify({method:"loaded", value: true}));
+          window.postMessage(JSON.stringify({method:"loaded", value: true}));
 
         }
 
-        if (WebViewBridge) {
-          if ( document.readyState === 'complete'  ) {
-            return _ready();
-          } else {
-            document.addEventListener( 'interactive', _ready, false );
-          }
+        if ( document.readyState === 'complete'  ) {
+          return _ready();
+        } else {
+          document.addEventListener( 'interactive', _ready, false );
         }
 
       }());
@@ -162,7 +154,7 @@ class EpubView extends Component {
       return;
     }
 
-    this.bridge.sendToBridge(str);
+    this.bridge.postMessage(str);
   }
 
   ask(method, args) {
@@ -252,8 +244,6 @@ class EpubView extends Component {
   _onLoad(e) {
     var format;
 
-    this.bridge = this.refs.webviewbridge;
-
     if (this.props.layout === "pre-paginated") {
       format = this.props.format(this.contents);
     } else if (this.props.horizontal) {
@@ -284,7 +274,7 @@ class EpubView extends Component {
 
   _onBridgeMessage(msg) {
 
-    var decoded = JSON.parse(msg);
+    var decoded = JSON.parse(msg.nativeEvent.data);
     var p;
     // console.log("msg", decoded);
 
@@ -450,8 +440,8 @@ class EpubView extends Component {
         onLayout={this._onLayout.bind(this)}
         >
         <TouchableWithoutFeedback onPress={this.props.onPress}>
-        <WebViewBridge
-          ref="webviewbridge"
+        <WebView
+          ref={webview => { this.bridge = webview }}
           key={`EpubViewSection:${this.props.section.index}`}
           style={[this.props.style, {
             width: this.state.width,
@@ -463,7 +453,7 @@ class EpubView extends Component {
           scalesPageToFit={false}
           scrollEnabled={false}
           onLoadEnd={this._onLoad.bind(this)}
-          onBridgeMessage={this._onBridgeMessage.bind(this)}
+          onMessage={this._onBridgeMessage.bind(this)}
           injectedJavaScript={this._injectedJavaScript}
           javaScriptEnabled={true}
         />

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "react-native": "0.37.0",
     "react-native-fetch-blob": "^0.10.0",
     "react-native-fs": "^2.0.1-rc.2",
-    "react-native-orientation": "yamill/react-native-orientation",
-    "react-native-webview-bridge": "^0.33.0"
+    "react-native-orientation": "yamill/react-native-orientation"
   },
   "devDependencies": {
     "babel-jest": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "events": "^1.1.1",
     "jszip": "^3.1.1",
     "lodash": "^4.14.0",
-    "react": "~15.3.1",
-    "react-native": "0.37.0",
     "react-native-fetch-blob": "^0.10.0",
     "react-native-fs": "^2.0.1-rc.2",
     "react-native-orientation": "yamill/react-native-orientation"
@@ -25,6 +23,8 @@
     "babel-preset-react-native": "1.9.0",
     "jest": "17.0.2",
     "jest-react-native": "17.0.2",
+    "react": "~15.3.1",
+    "react-native": "0.37.0",
     "react-test-renderer": "~15.3.1"
   },
   "jest": {


### PR DESCRIPTION
As noted in the [README of react-webview-bridge](https://github.com/alinz/react-native-webview-bridge), React Native now includes a `WebView` which supports a postMessage/onMessage interface. This PR updates epubjs-rn to use the included WebView instead of the bridge.