### PR TITLE
Added click position (x,y) to onPress

### DIFF
--- a/EpubReader/App.js
+++ b/EpubReader/App.js
@@ -80,7 +80,7 @@ class EpubReader extends Component {
                   toc: book.toc
                 });
               }}
-              onPress={(cfi, rendition)=> {
+              onPress={(cfi, position, rendition)=> {
                 this.toggleBars();
                 console.log("press", cfi);
               }}

--- a/src/Rendition.js
+++ b/src/Rendition.js
@@ -301,7 +301,7 @@ class Rendition extends Component {
         break;
       }
       case "press": {
-        this.props.onPress && this.props.onPress(decoded.cfi, this);
+        this.props.onPress && this.props.onPress(decoded.cfi, decoded.position, this);
         break;
       }
       case "longpress": {


### PR DESCRIPTION
It's needed for example if you want to tap on the right part of the screen and go to the next page vs. tap on the left part of the screen to go to the previous page.