### PR TITLE
Bugfix: rendition.prev() wasn't working

### DIFF
--- a/contents/bridge.js
+++ b/contents/bridge.js
@@ -213,7 +213,7 @@ window.onerror = function (message, file, line, col, error) {
         }
         case "prev": {
           if (rendition) {
-            rendition.next();
+            rendition.prev();
           } else {
             q.push(message);
           }


### PR DESCRIPTION
Sorry I hadn't tested this enough. Now .prev() function actually works.