### PR TITLE
Add type to unhighlight calls

### DIFF
--- a/EpubReader/App.js
+++ b/EpubReader/App.js
@@ -102,8 +102,9 @@ class EpubReader extends Component {
                 // Add marker
                 rendition.highlight(cfiRange, {});
               }}
-              onMarkClicked={(cfiRange) => {
+              onMarkClicked={(cfiRange, data, rendition) => {
                 console.log("mark clicked", cfiRange)
+                rendition.unhighlight(cfiRange);
               }}
               // themes={{
               //   tan: {

--- a/EpubReader/package.json
+++ b/EpubReader/package.json
@@ -5,13 +5,13 @@
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "test": "jest",
-    "move": "mv epubjs-rn-*.tgz epubjs-rn.r16.tgz",
+    "move": "mv epubjs-rn-*.tgz epubjs-rn.r17.tgz",
     "preinstall": "npm pack ../ && npm run move",
-    "postinstall": "rm epubjs-rn.r16.tgz"
+    "postinstall": "rm epubjs-rn.r17.tgz"
   },
   "dependencies": {
     "@react-native-community/slider": "^1.1.4",
-    "epubjs-rn": "file:./epubjs-rn.r16.tgz",
+    "epubjs-rn": "file:./epubjs-rn.r17.tgz",
     "react": "16.8.3",
     "react-native": "0.59.9",
     "react-native-vector-icons": "^6.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "epubjs-rn",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Rendition.js
+++ b/src/Rendition.js
@@ -243,16 +243,16 @@ class Rendition extends Component {
     this.sendToBridge("mark", [cfiRange, data]);
 	}
 
-  unhighlight (cfiRange, data) {
-    this.sendToBridge("removeAnnotation", [cfiRange, data]);
+  unhighlight (cfiRange) {
+    this.sendToBridge("removeAnnotation", [cfiRange, "highlight"]);
 	}
 
-	ununderline (cfiRange, data) {
-    this.sendToBridge("removeAnnotation", [cfiRange, data]);
+	ununderline (cfiRange) {
+    this.sendToBridge("removeAnnotation", [cfiRange, "underline"]);
 	}
 
-	unmark (cfiRange, data) {
-    this.sendToBridge("removeAnnotation", [cfiRange, data]);
+	unmark (cfiRange) {
+    this.sendToBridge("removeAnnotation", [cfiRange, "mark"]);
 	}
 
   next() {


### PR DESCRIPTION
Hash is was changed to be a combo of cfi and type in: https://github.com/futurepress/epub.js/commit/2cb5513fc61ec11071be724e096f1f2e82dde1f2

This updates the `unhighlight`, `unmark` and `ununderline` method to pass their types.