### PR TITLE
FIX: support for signed urls from s3 and other url file names with pa…

### DIFF
--- a/src/Streamer.js
+++ b/src/Streamer.js
@@ -128,7 +128,13 @@ class EpubStreamer {
 
   filename(bookUrl) {
     let uri = new Uri(bookUrl);
-    return uri.filename.replace(".epub", "");
+    let finalFileName;
+    if(uri.filename.indexOf("?") > -1) {
+        finalFileName = uri.filename.split("?")[0].replace(".epub", "");
+    } else {
+        finalFileName = uri.filename.replace(".epub", "");
+    }
+    return  finalFileName;
   }
 
   remove(path) {


### PR DESCRIPTION
Using this fine name changes we can use signed URLs as well from s3. Currently, it checked long params in URL which create an error 
{ [Error: failed to open zip file]
  framesToPop: 1,
  code: 'unzip_error',
  domain: 'SSZipArchiveErrorDomain',
  userInfo: { NSLocalizedDescription: 'failed to open zip file' } 

After this fix it will work fine, tested.